### PR TITLE
fix: protect shared vault databases

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.7
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.0
     hooks:
       - id: build-docs
         language: python

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MASTER]
+ignore=.venv

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright (c) 2017-2025 Splunk Inc.
+   Copyright (c) 2017-2026 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,2 @@
 Splunk SOAR App: SQLite
-Copyright (c) 2017-2025 Splunk Inc.
+Copyright (c) 2017-2026 Splunk Inc.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # SQLite
 
-Publisher: Splunk \
-Connector Version: 2.2.3 \
-Product Vendor: SQLite \
-Product Name: SQLite \
+Publisher: Splunk <br>
+Connector Version: 2.2.3 <br>
+Product Vendor: SQLite <br>
+Product Name: SQLite <br>
 Minimum Product Version: 6.1.1
 
 This app supports investigative actions against a local SQLite database
@@ -26,16 +26,16 @@ VARIABLE | REQUIRED | TYPE | DESCRIPTION
 
 ### Supported Actions
 
-[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration \
-[run query](#action-run-query) - Run a query against a table or tables in the database \
-[list columns](#action-list-columns) - List the columns of a table \
+[test connectivity](#action-test-connectivity) - Validate the asset configuration for connectivity using supplied configuration <br>
+[run query](#action-run-query) - Run a query against a table or tables in the database <br>
+[list columns](#action-list-columns) - List the columns of a table <br>
 [list tables](#action-list-tables) - List the tables in the database
 
 ## action: 'test connectivity'
 
 Validate the asset configuration for connectivity using supplied configuration
 
-Type: **test** \
+Type: **test** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -50,7 +50,7 @@ No Output
 
 Run a query against a table or tables in the database
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **False**
 
 It is recommended to use the <b>format_vars</b> parameter when applicable. For example, if you wanted to find a specific IP, you could set <b>query</b> to a formatted string, like "select * from my_hosts where ip = ?" (note the use of <b>?</b>), and set <b>format_vars</b> to the IP address. This will ensure the inputs are safely sanitized and avoid SQL injection attacks.<br><br>The <b>format_vars</b> parameter accepts a comma seperated list. You can escape commas by surrounding them in double quotes, and escape double quotes with a backslash. Assuming you have a list of values for the format vars, you can employ this code in your playbooks to properly format it into a string:<br> <code>format_vars_str = ','.join(['"{}"'.format(str(x).replace('\\\\', '\\\\\\\\').replace('"', '\\\\"')) for x in format_vars_list])</code><br><br>Setting <b>no_commit</b> will make it so the App does not commit any changes made to the database (so you can ensure it's a read only query).
@@ -83,7 +83,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List the columns of a table
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 The <b>table_name</b> parameter must be composed of only alphanumeric characters plus '\_' and '$'.
@@ -117,7 +117,7 @@ summary.total_objects_successful | numeric | | 1 |
 
 List the tables in the database
 
-Type: **investigate** \
+Type: **investigate** <br>
 Read only: **True**
 
 #### Action Parameters
@@ -146,7 +146,7 @@ ______________________________________________________________________
 
 Auto-generated Splunk SOAR Connector documentation.
 
-Copyright 2025 Splunk Inc.
+Copyright 2026 Splunk Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,6 @@
 # File: __init__.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Internal development tooling was refreshed for this connector.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,3 @@
 **Unreleased**
 
-* Internal development tooling was refreshed for this connector.
+* Scope vault database access to the current container and open vault files read-only

--- a/sqlite.html
+++ b/sqlite.html
@@ -11,7 +11,7 @@
 {% block widget_content %}
   <!-- Main Start Block -->
   <!-- File: sqlite.html
-  Copyright (c) 2017-2025 Splunk Inc.
+  Copyright (c) 2017-2026 Splunk Inc.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.

--- a/sqlite.json
+++ b/sqlite.json
@@ -9,7 +9,7 @@
     "product_name": "SQLite",
     "product_version_regex": ".*",
     "publisher": "Splunk",
-    "license": "Copyright (c) 2017-2025 Splunk Inc.",
+    "license": "Copyright (c) 2017-2026 Splunk Inc.",
     "app_version": "2.2.3",
     "utctime_updated": "2025-08-01T20:38:43.596014Z",
     "package_name": "phantom_sqlite",
@@ -405,5 +405,11 @@
             },
             "versions": "EQ(*)"
         }
-    ]
+    ],
+    "pip39_dependencies": {
+        "wheel": []
+    },
+    "pip313_dependencies": {
+        "wheel": []
+    }
 }

--- a/sqlite_connector.py
+++ b/sqlite_connector.py
@@ -17,6 +17,7 @@ import json
 import os
 import re
 import sqlite3
+from pathlib import Path
 
 import phantom.app as phantom
 import phantom.rules as phrules
@@ -207,10 +208,11 @@ class SqliteConnector(BaseConnector):
         return phantom.APP_ERROR
 
     def _init_db(self, vault_id=None):
+        use_uri = False
         if vault_id:
-            # get file location from vault
+            # Scope vault lookup to the container running this action.
             try:
-                _success, _message, file_info = phrules.vault_info(vault_id=vault_id)
+                _success, _message, file_info = phrules.vault_info(vault_id=vault_id, container_id=self.get_container_id())
                 file_info = next(iter(file_info))
             except IndexError:
                 return self._initialize_error("Vault file could not be found with supplied Vault ID")
@@ -218,13 +220,26 @@ class SqliteConnector(BaseConnector):
                 return self._initialize_error("Vault ID not valid")
 
             path = file_info.get("path")
+            if not path:
+                return self._initialize_error("Vault file did not include a usable path")
+
+            # Vault files are content-addressed and may be shared by multiple
+            # containers. Open them read-only so a query cannot modify shared
+            # bytes while the platform continues serving the original digest.
+            path = f"{Path(path).resolve().as_uri()}?mode=ro"
+            use_uri = True
 
         else:
             # use asset configured db file
             path = self._asset_db_path
 
         try:
-            self._connection = sqlite3.connect(path, detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES, isolation_level=None)
+            self._connection = sqlite3.connect(
+                path,
+                detect_types=sqlite3.PARSE_DECLTYPES | sqlite3.PARSE_COLNAMES,
+                isolation_level=None,
+                uri=use_uri,
+            )
             self._cursor = self._connection.cursor()
         except Exception as e:
             return self._initialize_error("Error connecting to database", e)

--- a/sqlite_connector.py
+++ b/sqlite_connector.py
@@ -1,6 +1,6 @@
 # File: sqlite_connector.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -210,7 +210,7 @@ class SqliteConnector(BaseConnector):
         if vault_id:
             # get file location from vault
             try:
-                success, message, file_info = phrules.vault_info(vault_id=vault_id)
+                _success, _message, file_info = phrules.vault_info(vault_id=vault_id)
                 file_info = next(iter(file_info))
             except IndexError:
                 return self._initialize_error("Vault file could not be found with supplied Vault ID")

--- a/sqlite_consts.py
+++ b/sqlite_consts.py
@@ -1,6 +1,6 @@
 # File: sqlite_consts.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sqlite_view.py
+++ b/sqlite_view.py
@@ -1,6 +1,6 @@
 # File: sqlite_view.py
 #
-# Copyright (c) 2017-2025 Splunk Inc.
+# Copyright (c) 2017-2026 Splunk Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
### Bug Fixes

- Scope `vault_id` resolution to the container running the action.
- Open content-addressed vault database files through a read-only SQLite URI.
- Preserve writable behavior for asset-configured database paths.

Tracks ESPM-5228 and PAPP-37961. Addresses PSAAS-32099.

Validation: `pre-commit run --all-files`, Python compilation, JSON parsing, `git diff --check`, and signed-commit verification.

### Manual Documentation

- [x] I have verified that manual documentation has been updated where appropriate. No manual documentation changes are required.

### Other information

The supplied patch was treated as a recommendation and adapted to percent-encode the vault path through `Path.as_uri()` before enabling SQLite URI mode. The connector-side fix prevents cross-container lookup and in-place mutation; platform-level vault immutability and digest enforcement remain a separate cross-cutting defense-in-depth concern.

Written by Codex.

---
Please refer to our [Contribution Guide](https://github.com/splunk-soar-connectors/.github/blob/main/.github/CONTRIBUTING.md) for any questions on submitting a pull request.

Thanks for contributing!