### PR TITLE
fix: preserve duplicate SQLite query columns

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.2.0
+    rev: v2.2.8
     hooks:
       - id: build-docs
         language: python

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Preserved all values from query results that contain duplicate column names.

--- a/sqlite_connector.py
+++ b/sqlite_connector.py
@@ -52,8 +52,20 @@ class SqliteConnector(BaseConnector):
 
     def _get_query_results(self, action_result):
         try:
-            columns = self._cursor.description
-            results = [{columns[index][0]: column for index, column in enumerate(value)} for value in self._cursor.fetchall()]
+            column_names = []
+            used_names = set()
+            for index, column in enumerate(self._cursor.description):
+                column_name = column[0]
+                if column_name in used_names:
+                    duplicate_name = f"{column_name}__duplicate_{index}"
+                    duplicate_index = 1
+                    while duplicate_name in used_names:
+                        duplicate_name = f"{column_name}__duplicate_{index}_{duplicate_index}"
+                        duplicate_index += 1
+                    column_name = duplicate_name
+                used_names.add(column_name)
+                column_names.append(column_name)
+            results = [dict(zip(column_names, value)) for value in self._cursor.fetchall()]
         except Exception as e:
             return RetVal(action_result.set_status(phantom.APP_ERROR, "Unable to retrieve results from query", e))
 


### PR DESCRIPTION
### Bug Fixes

- Preserves every value from query results with duplicate column names by keeping the first name and assigning deterministic unique names to later collisions.

### Manual Documentation

- [x] No manual documentation update is needed: action behavior and inputs are unchanged.

### Other information

- Tracking: PAPP-38319, PSAAS-32871 (VULN-95864; FS-4558).
- Validation: Python 3.13 focused duplicate-column serialization test, Python compile, and full v2.2.8 pre-commit suite including Docker package-app-dependencies.
- Written by Codex.